### PR TITLE
Refactor: Implement Roadtrip Radio features

### DIFF
--- a/src/components/ArtistCard.tsx
+++ b/src/components/ArtistCard.tsx
@@ -2,23 +2,18 @@
 import { Card } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { CheckCircle2, Music, Play, Plus } from "lucide-react";
+import { CheckCircle2, Disc3, ExternalLink, Music, Play, Plus } from "lucide-react";
+import { ArtistWithDetails } from "@/utils/spotify";
+import { Badge } from "./ui/badge";
 
 interface ArtistCardProps {
-  artist: {
-    id: string;
-    name: string;
-    location: string;
-    imageUrl?: string;
-    topTrack?: string;
-    spotifyId?: string;
-  };
+  artist: ArtistWithDetails;
   isSelected?: boolean;
   onToggle?: () => void;
 }
 
 const ArtistCard = ({ artist, isSelected = false, onToggle }: ArtistCardProps) => {
-  const { name, location, imageUrl, topTrack } = artist;
+  const { name, imageUrl, topTrack, genres } = artist;
   
   const initials = name
     .split(' ')
@@ -27,12 +22,19 @@ const ArtistCard = ({ artist, isSelected = false, onToggle }: ArtistCardProps) =
     .toUpperCase()
     .slice(0, 2);
 
+  const openSpotifyLink = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (artist.spotifyId) {
+      window.open(`https://open.spotify.com/artist/${artist.spotifyId}`, '_blank');
+    }
+  };
+
   return (
-    <Card className="album-card border-0 shadow-md group">
+    <Card className="album-card border-0 shadow-md group cursor-pointer" onClick={onToggle}>
       <div className="relative aspect-square bg-gradient-to-br from-muted to-muted/30 overflow-hidden">
         <Avatar className="h-full w-full rounded-none">
           <AvatarImage 
-            src={imageUrl} 
+            src={imageUrl || undefined} 
             alt={name} 
             className="object-cover h-full w-full transition-transform group-hover:scale-110"
           />
@@ -42,27 +44,42 @@ const ArtistCard = ({ artist, isSelected = false, onToggle }: ArtistCardProps) =
         </Avatar>
         <div className="absolute bottom-0 left-0 w-full p-4 bg-gradient-to-t from-black/70 to-transparent text-white">
           <h3 className="font-bold text-lg tracking-tight">{name}</h3>
-          <p className="text-sm opacity-90">{location}</p>
+          {genres && genres.length > 0 && (
+            <div className="flex flex-wrap gap-1 mt-1">
+              {genres.slice(0, 2).map(genre => (
+                <Badge key={genre} variant="outline" className="text-xs bg-black/30 border-none text-white">
+                  {genre}
+                </Badge>
+              ))}
+            </div>
+          )}
         </div>
-        <Button 
-          size="icon" 
-          variant="secondary" 
-          className="absolute right-3 bottom-3 rounded-full opacity-0 group-hover:opacity-100 transition-opacity bg-white text-black hover:bg-white/90"
-        >
-          <Play className="h-4 w-4 fill-current" />
-        </Button>
+        
+        {artist.spotifyId && (
+          <Button 
+            size="icon" 
+            variant="secondary" 
+            className="absolute right-3 bottom-3 rounded-full opacity-0 group-hover:opacity-100 transition-opacity bg-white text-black hover:bg-white/90"
+            onClick={openSpotifyLink}
+          >
+            <ExternalLink className="h-4 w-4" />
+          </Button>
+        )}
+        
         {isSelected && (
           <div className="absolute top-3 right-3 bg-[#1DB954] text-white rounded-full p-1">
             <CheckCircle2 size={20} />
           </div>
         )}
       </div>
-      <div className="album-card-content flex items-center justify-between">
-        {topTrack && (
-          <div className="flex flex-col">
-            <span className="text-xs text-muted-foreground">Top track</span>
+      <div className="p-3 flex items-center justify-between">
+        {topTrack ? (
+          <div className="flex items-center gap-2">
+            <Disc3 className="h-4 w-4 text-muted-foreground" />
             <span className="font-medium truncate max-w-[180px]">{topTrack}</span>
           </div>
+        ) : (
+          <span className="text-sm text-muted-foreground">No top track found</span>
         )}
         <Button 
           variant="ghost" 

--- a/src/components/RouteForm.tsx
+++ b/src/components/RouteForm.tsx
@@ -6,15 +6,7 @@ import { Card, CardContent } from "@/components/ui/card";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { ArrowRight, MapPin, Music } from "lucide-react";
 import { useToast } from "@/hooks/use-toast";
-import { Badge } from "./ui/badge";
-
-const FESTIVALS = [
-  { id: 'glastonbury', name: 'Glastonbury Festival', location: 'Pilton, UK' },
-  { id: 'coachella', name: 'Coachella', location: 'Indio, California' },
-  { id: 'tomorrowland', name: 'Tomorrowland', location: 'Boom, Belgium' },
-  { id: 'rockwerchter', name: 'Rock Werchter', location: 'Werchter, Belgium' },
-  { id: 'lollapalooza', name: 'Lollapalooza', location: 'Chicago, Illinois' },
-];
+import { festivals, FestivalData } from "@/data/festivals";
 
 interface RouteFormProps {
   onSubmit: (data: {
@@ -50,12 +42,14 @@ const RouteForm = ({ onSubmit }: RouteFormProps) => {
       return;
     }
     
-    const selectedFestival = FESTIVALS.find(f => f.id === festival);
+    const selectedFestival = festivals.find(f => 
+      f.festival_name.toLowerCase().replace(/\s+/g, '') === festival.toLowerCase()
+    );
     
     if (selectedFestival) {
       onSubmit({
         startLocation,
-        endLocation: selectedFestival.location,
+        endLocation: selectedFestival.festival_name,
         festival
       });
     }
@@ -101,11 +95,17 @@ const RouteForm = ({ onSubmit }: RouteFormProps) => {
                 <SelectValue placeholder="Choose a festival" />
               </SelectTrigger>
               <SelectContent>
-                {FESTIVALS.map((fest) => (
-                  <SelectItem key={fest.id} value={fest.id} className="flex items-center justify-between">
+                {festivals.map((fest) => (
+                  <SelectItem 
+                    key={fest.festival_name.toLowerCase().replace(/\s+/g, '')} 
+                    value={fest.festival_name.toLowerCase().replace(/\s+/g, '')}
+                    className="flex items-center justify-between"
+                  >
                     <div className="flex flex-col">
-                      <span>{fest.name}</span>
-                      <span className="text-xs text-muted-foreground">{fest.location}</span>
+                      <span>{fest.festival_name}</span>
+                      <span className="text-xs text-muted-foreground">
+                        {new Date(fest.start_date).toLocaleDateString()} - {new Date(fest.end_date).toLocaleDateString()}
+                      </span>
                     </div>
                   </SelectItem>
                 ))}

--- a/src/components/StageArtistList.tsx
+++ b/src/components/StageArtistList.tsx
@@ -1,0 +1,57 @@
+
+import { useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import ArtistCard from "./ArtistCard";
+import { ArtistWithDetails } from "@/utils/spotify";
+
+interface StageArtistListProps {
+  stageName: string;
+  artists: ArtistWithDetails[];
+  isMainStage: boolean;
+  selectedArtists: string[];
+  onArtistToggle: (artistId: string) => void;
+}
+
+const StageArtistList = ({ 
+  stageName, 
+  artists, 
+  isMainStage, 
+  selectedArtists, 
+  onArtistToggle 
+}: StageArtistListProps) => {
+  const [isExpanded, setIsExpanded] = useState(isMainStage);
+  
+  return (
+    <div className="mb-8">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-xl font-semibold">{stageName}</h3>
+          {isMainStage && (
+            <Badge className="bg-festival-pink text-white">Main Stage</Badge>
+          )}
+        </div>
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="text-sm text-muted-foreground hover:text-foreground"
+        >
+          {isExpanded ? "Collapse" : "Expand"}
+        </button>
+      </div>
+      
+      {isExpanded && (
+        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+          {artists.map((artist) => (
+            <ArtistCard
+              key={artist.name}
+              artist={artist}
+              isSelected={selectedArtists.includes(artist.name)}
+              onToggle={() => onArtistToggle(artist.name)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default StageArtistList;

--- a/src/data/festivals.ts
+++ b/src/data/festivals.ts
@@ -1,0 +1,886 @@
+export interface FestivalData {
+  festival_name: string;
+  start_date: string;
+  end_date: string;
+  main_stages: string[];
+  stages: {
+    [stageName: string]: string[];
+  };
+}
+
+export const festivals: FestivalData[] = [
+  {
+    "festival_name": "All Points East 2025",
+    "start_date": "2025-08-16",
+    "end_date": "2025-08-24",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Chase and Status",
+        "Overmono",
+        "Sammy Virji",
+        "Nia Archives",
+        "Dimension",
+        "Jyoty",
+        "Joy Orbison",
+        "Shy FX",
+        "Barry Can't Swim",
+        "Confidence Man",
+        "Shygirl",
+        "Marlon Hoffstadt",
+        "RAYE",
+        "Tyla",
+        "Doechii",
+        "JADE",
+        "The Maccabees",
+        "Bombay Bicycle Club",
+        "Dry Cleaning",
+        "The Cribs",
+        "Nilüfer Yanya"
+      ]
+    }
+  },
+  {
+    "festival_name": "Boardmasters Festival 2025",
+    "start_date": "2025-08-06",
+    "end_date": "2025-08-10",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "The Prodigy",
+        "London Grammar",
+        "Nelly Furtado",
+        "RAYE",
+        "Kaiser Chiefs",
+        "Rizzle Kicks",
+        "Natasha Bedingfield",
+        "Myles Smith"
+      ],
+      "Land Of Saints Stage": [
+        "Wet Leg",
+        "Franz Ferdinand",
+        "Ocean Alley",
+        "Bob Vylan",
+        "Orla Gartland",
+        "Newton Faulkner"
+      ],
+      "Unleashed Stage": [
+        "Maribou State",
+        "Bru-C",
+        "Bou",
+        "Hard Life",
+        "Interplanetary Criminal",
+        "Ahadadream",
+        "Arielle Free",
+        "Sally C",
+        "Dan Shake",
+        "Deadletter",
+        "Emily Makis",
+        "Gardna",
+        "Lu.Re",
+        "Luvcat",
+        "Paige Tomlinson",
+        "Sim0ne",
+        "Storm Mollison",
+        "Waze"
+      ]
+    }
+  },
+  {
+    "festival_name": "Boomtown Fair 2025",
+    "start_date": "2025-08-06",
+    "end_date": "2025-08-10",
+    "main_stages": ["Grand Central", "The Lion's Gate"],
+    "stages": {
+      "Grand Central": [
+        "Sex Pistols ft Frank Carter",
+        "Sean Paul",
+        "CASISDEAD",
+        "Pa Salieu",
+        "Overmono",
+        "Nia Archives",
+        "Joy Orbison",
+        "Jyoty"
+      ],
+      "The Lion's Gate": [
+        "Maribou State",
+        "The Wailers",
+        "BONEY M. feat. Maizie Williams",
+        "I Hate Models",
+        "Girls Don't Sync",
+        "Jayda G",
+        "Dub FX",
+        "Alien Ant Farm"
+      ]
+    }
+  },
+  {
+    "festival_name": "BST Hyde Park 2025",
+    "start_date": "2025-06-28",
+    "end_date": "2025-07-13",
+    "main_stages": ["Great Oak Stage"],
+    "stages": {
+      "Great Oak Stage": [
+        "Sabrina Carpenter",
+        "Olivia Rodrigo",
+        "Zach Bryan",
+        "Noel Gallagher",
+        "Hugh Jackman",
+        "Jeff Lynne's ELO"
+      ]
+    }
+  },
+  {
+    "festival_name": "Creamfields 2025",
+    "start_date": "2025-08-21",
+    "end_date": "2025-08-24",
+    "main_stages": ["ARC Stage"],
+    "stages": {
+      "ARC Stage": [
+        "Swedish House Mafia",
+        "David Guetta",
+        "Martin Garrix",
+        "Chase & Status",
+        "Anyma",
+        "Amelie Lens",
+        "Adam Beyer",
+        "Boris Brejcha",
+        "Andy C",
+        "Oliver Heldens",
+        "Jodie Harsh",
+        "Hannah Laing",
+        "Max Dean"
+      ]
+    }
+  },
+  {
+    "festival_name": "Download Festival 2025",
+    "start_date": "2025-06-13",
+    "end_date": "2025-06-15",
+    "main_stages": ["Apex Stage"],
+    "stages": {
+      "Apex Stage": [
+        "Green Day",
+        "Weezer",
+        "Jimmy Eat World",
+        "Rise Against",
+        "Boston Manor",
+        "CKY",
+        "SiM",
+        "Sleep Token",
+        "Shinedown",
+        "Don Broco",
+        "Palaye Royale",
+        "Poppy",
+        "Hatebreed",
+        "Loathe",
+        "Static Dress",
+        "Korn",
+        "Bullet For My Valentine",
+        "Spiritbox",
+        "Meshuggah",
+        "Jinjer",
+        "Power Trip",
+        "Bleed From Within",
+        "Orbit Culture"
+      ],
+      "Opus Stage": [
+        "Within Temptation",
+        "Opeth",
+        "Myles Kennedy",
+        "Starset",
+        "Northlane",
+        "Dirty Honey",
+        "The Scratch",
+        "Sex Pistols ft Frank Carter",
+        "The Darkness",
+        "Eagles Of Death Metal",
+        "Polaris",
+        "Awolnation",
+        "Currents",
+        "Kim Dracula",
+        "Sophie Lloyd",
+        "Steel Panther",
+        "Lorna Shore",
+        "Airbourne",
+        "Jerry Cantrell",
+        "Alien Ant Farm",
+        "Municipal Waste",
+        "The Ghost Inside",
+        "Nothing More",
+        "Seven Hours",
+        "After Violet",
+        "The Southern River Band"
+      ],
+      "Avalanche Stage": [
+        "McFly",
+        "Elliot Minor",
+        "Crossfaith",
+        "Trophy Eyes",
+        "Bad Nerves",
+        "The Meffs",
+        "Unpeople",
+        "Dead Pony",
+        "Karen Dió",
+        "Dayseeker",
+        "Mallory Knox",
+        "Twin Atlantic",
+        "Smash Into Pieces",
+        "Mothica",
+        "Lølø",
+        "Split Chain",
+        "Venus Grrrls",
+        "Bex",
+        "Kids In Glass Houses",
+        "Me First and the Gimme Gimmes",
+        "Turbonegro",
+        "Dead Poet Society",
+        "House Of Protection",
+        "Spiritual Cramp",
+        "Amira Elfeky",
+        "Arrows In Action",
+        "Harpy"
+      ],
+      "Dogtooth Stage": [
+        "Apocalyptica",
+        "Eivør",
+        "Alcest",
+        "Vola",
+        "Svalbard",
+        "Windhand",
+        "Graphic Nature",
+        "Riding The Low",
+        "Gore.",
+        "Battlesnake",
+        "The Haunt",
+        "Cradle Of Filth",
+        "Sylosis",
+        "Kittie",
+        "Anaal Nathrakh",
+        "The Funeral Portrait",
+        "Teen Mortgage",
+        "Holy Wars",
+        "Underside",
+        "Zetra",
+        "Bastardane",
+        "Lastelle",
+        "Artio",
+        "SikTh",
+        "Whitechapel",
+        "Fit For An Autopsy",
+        "Cattle Decapitation",
+        "Novelists",
+        "Unprocessed",
+        "President",
+        "VOWWS",
+        "Survive Said The Prophet",
+        "VOWER",
+        "Faetooth",
+        "Archers",
+        "Neckbreakker"
+      ]
+    }
+  },
+  {
+    "festival_name": "Field Day 2025",
+    "start_date": "2025-05-24",
+    "end_date": "2025-05-25",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Peggy Gou"
+      ]
+    }
+  },
+  {
+    "festival_name": "Glastonbury Festival 2025",
+    "start_date": "2025-06-25",
+    "end_date": "2025-06-29",
+    "main_stages": ["Pyramid Stage", "Other Stage"],
+    "stages": {
+      "Pyramid Stage": [
+        "The 1975",
+        "Neil Young and the Chrome Hearts",
+        "Olivia Rodrigo",
+        "Rod Stewart",
+        "RAYE",
+        "Biffy Clyro",
+        "Alanis Morissette",
+        "Busta Rhymes",
+        "Wet Leg",
+        "Franz Ferdinand",
+        "Supergrass"
+      ],
+      "Other Stage": [
+        "Loyle Carner",
+        "Charli XCX",
+        "The Prodigy",
+        "The Libertines",
+        "Kaiser Chiefs",
+        "Kneecap",
+        "Wolf Alice",
+        "Doechii"
+      ],
+      "West Holts": [
+        "Maribou State",
+        "Doechii",
+        "Overmono"
+      ],
+      "Woodsies": [
+        "Four Tet",
+        "Scissor Sisters",
+        "Jorja Smith",
+        "St. Vincent",
+        "Blossoms",
+        "TV On The Radio"
+      ],
+      "Acoustic Stage": [
+        "Ani DiFranco",
+        "Nick Lowe",
+        "Roy Harper",
+        "Gabrielle Aplin",
+        "The Bootleg Beatles"
+      ],
+      "Field Of Avalon": [
+        "Ash",
+        "Hard-Fi",
+        "The Fratellis",
+        "Sam Ryder",
+        "Bear's Den"
+      ],
+      "Left Field": [
+        "Lambrini Girls",
+        "Kate Nash",
+        "Reverend And The Makers",
+        "Grandson"
+      ],
+      "The Glade Stage": [
+        "Leftfield",
+        "Carl Cox & Eric Powell's Mobile Disco",
+        "Skepta B2B Mochakk B2B Carlita",
+        "Richie Hawtin",
+        "Amelie Lens",
+        "Goldie (Live)",
+        "Joy Orbison",
+        "Seth Troxler",
+        "Annie Mac",
+        "Third World",
+        "Max Cooper",
+        "Interplanetary Criminal B2B Kettama",
+        "Sherelle",
+        "Eliza Rose",
+        "Ross From Friends",
+        "Daniel Avery B2B Imogen",
+        "MJ Cole",
+        "Sally C",
+        "Fish 56 Octagon",
+        "Deep Dish",
+        "A Guy Called Gerald + The Jungle Drummer",
+        "Nabihah Iqbal",
+        "Crazy P",
+        "The Orb",
+        "Marshall Jefferson",
+        "Lauren Lo Sung",
+        "Tunng",
+        "K.Klass",
+        "K.O.G",
+        "Dele Sosimi Afrobeat Experience",
+        "Bel Cobain",
+        "Don Letts (DJ)",
+        "Channel One Sound System",
+        "Omega Nebula",
+        "Electric Jalaba"
+      ],
+      "Glade Dome": [
+        "Daphni",
+        "DJ Boring B2B DJ Seinfeld",
+        "Jamz Supernova B2B Shy One",
+        "Leon Vynehall",
+        "Fabio & Grooverider",
+        "Calibre",
+        "DJ Tennis & Ashee pres. Tenashee (Live)",
+        "Eli Brown",
+        "A Little Sound",
+        "Dyed Soundorom",
+        "Mathew Jonson (Live)",
+        "Margaret Dygas",
+        "Bradley Zero",
+        "Ion Ludwig (Live)",
+        "Tommy Holohan",
+        "Saoirse",
+        "Charlie Tee",
+        "Gray"
+      ]
+    }
+  },
+  {
+    "festival_name": "Green Man 2025",
+    "start_date": "2025-08-14",
+    "end_date": "2025-08-17",
+    "main_stages": ["Mountain Stage"],
+    "stages": {
+      "Mountain Stage": [
+        "Underworld",
+        "Wet Leg",
+        "TV On The Radio",
+        "Kneecap",
+        "Beth Gibbons"
+      ],
+      "Far Out Stage": [
+        "Wunderhorse",
+        "CMAT"
+      ]
+    }
+  },
+  {
+    "festival_name": "Isle of Wight Festival 2025",
+    "start_date": "2025-06-19",
+    "end_date": "2025-06-22",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Sting",
+        "Faithless",
+        "The Corrs",
+        "Amy MacDonald",
+        "Lottery Winners",
+        "Stereophonics",
+        "The Script",
+        "Paul Heaton ft. Rianne Downey",
+        "Busted",
+        "Razorlight",
+        "The Saw Doctors",
+        "Mae Muller",
+        "Emmanuel Kelly",
+        "5 Degrees North",
+        "Justin Timberlake",
+        "Jess Glynne",
+        "Texas",
+        "Olly Murs",
+        "Alison Moyet",
+        "Ella Eyre",
+        "Björn Again"
+      ],
+      "Big Top": [
+        "Example",
+        "The Pigeon Detectives",
+        "Rhythm of the 90s",
+        "The Smyths",
+        "Clean Bandit",
+        "Dean Lewis",
+        "The Lathums",
+        "Amble",
+        "Twin Atlantic",
+        "Crystal Tides",
+        "Supergrass",
+        "Yard Act",
+        "English Teacher",
+        "Pale Waves",
+        "Arthur Hill",
+        "Matilda Mann",
+        "The Clause",
+        "James",
+        "Lightning Seeds",
+        "Alessi Rose",
+        "Nieve Ella",
+        "Midge Ure",
+        "Remember Monday"
+      ]
+    }
+  },
+  {
+    "festival_name": "Kendal Calling 2025",
+    "start_date": "2025-07-31",
+    "end_date": "2025-08-03",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Courteeners",
+        "Fatboy Slim",
+        "The Prodigy"
+      ]
+    }
+  },
+  {
+    "festival_name": "Latitude Festival 2025",
+    "start_date": "2025-07-24",
+    "end_date": "2025-07-27",
+    "main_stages": ["Obelisk Arena"],
+    "stages": {
+      "Obelisk Arena": [
+        "Sting",
+        "Snow Patrol",
+        "Elbow"
+      ],
+      "BBC Sounds Stage": [
+        "Fatboy Slim",
+        "Basement Jaxx",
+        "Maribou State"
+      ]
+    }
+  },
+  {
+    "festival_name": "Leeds Festival 2025",
+    "start_date": "2025-08-22",
+    "end_date": "2025-08-24",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Travis Scott",
+        "Bring Me The Horizon",
+        "Hozier",
+        "Chappell Roan",
+        "Limp Bizkit",
+        "D-Block Europe",
+        "AJ Tracey",
+        "Becky Hill",
+        "Enter Shikari",
+        "The Kooks",
+        "Bloc Party",
+        "Trippie Redd",
+        "Conan Gray",
+        "Amyl and The Sniffers",
+        "Wunderhorse",
+        "Royel Otis",
+        "Del Water Gap",
+        "Balming Tiger",
+        "Alessi Rose",
+        "DJ EZ",
+        "Rudimental",
+        "High Vis",
+        "Bilmuri",
+        "Blanco",
+        "Issey Cross",
+        "Antony Szmierek",
+        "Mannequin Pussy",
+        "Girls Don’t Sync",
+        "Good Kid",
+        "Nieve Ella",
+        "Lancey Foux",
+        "The Dare",
+        "Suki Waterhouse",
+        "Sofia Isella",
+        "Lambrini Girls",
+        "Snow Strippers",
+        "Soft Play",
+        "Luvcat",
+        "Sea Girls",
+        "Pale Waves",
+        "Songer",
+        "The Chats",
+        "Wallows",
+        "Lola Young",
+        "The Linda Lindas",
+        "South Arcade",
+        "Bakar",
+        "Good Neighbours",
+        "Matilda Mann",
+        "Nemzzz",
+        "Badger",
+        "Example",
+        "The Royston Club",
+        "Jazzy",
+        "Nell Mescal",
+        "Heartworms",
+        "Pozer",
+        "VLURE",
+        "Been Stellar",
+        "Balu Brigada",
+        "Jasmine.4.t",
+        "SNAYX",
+        "AViVa",
+        "Ecca Vandal",
+        "Glixen",
+        "Good Health Good Wealth",
+        "House of Protection",
+        "Mouth Culture",
+        "Origami Angel",
+        "Red Rum Club",
+        "Rifle",
+        "VOILÀ"
+      ]
+    }
+  },
+  {
+    "festival_name": "Noisily Festival 2025",
+    "start_date": "2025-07-11",
+    "end_date": "2025-07-13",
+    "main_stages": ["Noisily Stage"],
+    "stages": {
+      "Noisily Stage": [
+        "Britta Arnold",
+        "Goldie (with MC Medic)",
+        "Victor Ruiz b2b Alex Stein"
+      ]
+    }
+  },
+  {
+    "festival_name": "Parklife 2025",
+    "start_date": "2025-06-13",
+    "end_date": "2025-06-14",
+    "main_stages": ["The Valley"],
+    "stages": {
+      "The Valley": [
+        "50 Cent",
+        "Charli XCX",
+        "Jorja Smith",
+        "Lola Young",
+        "Rudimental",
+        "Confidence Man",
+        "FLO"
+      ],
+      "The Hangar": [
+        "Peggy Gou",
+        "PAWSA",
+        "Bicep (DJ Set)",
+        "Overmono",
+        "Chris Stussy",
+        "Skream & Benga",
+        "Interplanetary Criminal",
+        "Ewan McVicar",
+        "Mochakk",
+        "Partiboi69",
+        "Prospa"
+      ],
+      "Magic Sky": [
+        "Hybrid Minds",
+        "Andy C",
+        "Hedex",
+        "Bou",
+        "Girls Don’t Sync",
+        "DJ Heartstring",
+        "salute"
+      ]
+    }
+  },
+  {
+    "festival_name": "Reading Festival 2025",
+    "start_date": "2025-08-22",
+    "end_date": "2025-08-24",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Travis Scott",
+        "Bring Me The Horizon",
+        "Hozier",
+        "Chappell Roan",
+        "Limp Bizkit",
+        "D-Block Europe",
+        "AJ Tracey",
+        "Becky Hill",
+        "Enter Shikari",
+        "The Kooks",
+        "Bloc Party",
+        "Trippie Redd",
+        "Conan Gray",
+        "Amyl and The Sniffers",
+        "Wunderhorse",
+        "Royel Otis",
+        "Del Water Gap",
+        "Balming Tiger",
+        "Alessi Rose",
+        "DJ EZ",
+        "Rudimental",
+        "High Vis",
+        "Bilmuri",
+        "Blanco",
+        "Issey Cross",
+        "Antony Szmierek",
+        "Mannequin Pussy",
+        "Girls Don’t Sync",
+        "Good Kid",
+        "Nieve Ella",
+        "Lancey Foux",
+        "The Dare",
+        "Suki Waterhouse",
+        "Sofia Isella",
+        "Lambrini Girls",
+        "Snow Strippers",
+        "Soft Play",
+        "Luvcat",
+        "Sea Girls",
+        "Pale Waves",
+        "Songer",
+        "The Chats",
+        "Wallows",
+        "Lola Young",
+        "The Linda Lindas",
+        "South Arcade",
+        "Bakar",
+        "Good Neighbours",
+        "Matilda Mann",
+        "Nemzzz",
+        "Badger",
+        "Example",
+        "The Royston Club",
+        "Jazzy",
+        "Nell Mescal",
+        "Heartworms",
+        "Pozer",
+        "VLURE",
+        "Been Stellar",
+        "Balu Brigada",
+        "Jasmine.4.t",
+        "SNAYX",
+        "AViVa",
+        "Ecca Vandal",
+        "Glixen",
+        "Good Health Good Wealth",
+        "House of Protection",
+        "Mouth Culture",
+        "Origami Angel",
+        "Red Rum Club",
+        "Rifle",
+        "VOILÀ"
+      ]
+    }
+  },
+  {
+    "festival_name": "TRNSMT Festival 2025",
+    "start_date": "2025-07-11",
+    "end_date": "2025-07-13",
+    "main_stages": ["Main Stage", "King Tut's Stage"],
+    "stages": {
+      "Main Stage": [
+        "50 Cent",
+        "The Script",
+        "Wet Leg",
+        "Jamie Webster",
+        "Twin Atlantic",
+        "Biffy Clyro",
+        "Fontaines D.C.",
+        "The Kooks",
+        "Inhaler",
+        "Sigrid",
+        "Snow Patrol",
+        "Gracie Abrams",
+        "Shed Seven",
+        "The Lathums",
+        "Nina Nesbitt"
+      ],
+      "King Tut's Stage": [
+        "Kneecap",
+        "Confidence Man",
+        "The Royston Club",
+        "Calum Bowie",
+        "Tanner Adell",
+        "Good Neighbours",
+        "Arthur Hill",
+        "NOFUN!",
+        "Underworld",
+        "Jake Bugg",
+        "Alessi Rose",
+        "James Marriott",
+        "Biig Piig",
+        "Amble",
+        "Lucia & The Best Boys",
+        "Brògeal",
+        "Tom Walker",
+        "Brooke Combe",
+        "Kyle Falconer"
+      ],
+      "BBC Radio 1 Dance Stage": [
+        "Jaguar",
+        "La La",
+        "Connor Coates",
+        "Big Miz",
+        "Marianne",
+        "Frankie Elysie",
+        "Nimino",
+        "Hayley",
+        "Zalassi",
+        "Arielle Free",
+        "Hannah Opgaard",
+        "Dominique",
+        "Eva",
+        "JAZZY",
+        "BETH",
+        "Sarah Story",
+        "Charlie Hedges",
+        "Kane Kirkpatrick",
+        "Beaux"
+      ]
+    }
+  },
+  {
+    "festival_name": "Victorious Festival 2025",
+    "start_date": "2025-08-22",
+    "end_date": "2025-08-24",
+    "main_stages": ["Common Stage", "Castle Stage"],
+    "stages": {
+      "Common Stage": [
+        "Queens of the Stone Age",
+        "Vampire Weekend",
+        "Kings of Leon",
+        "Michael Kiwanuka",
+        "Bloc Party",
+        "The Charlatans",
+        "The Last Dinner Party"
+      ],
+      "Castle Stage": [
+        "Madness",
+        "Nelly Furtado",
+        "Travis",
+        "Rizzle Kicks"
+      ]
+    }
+  },
+  {
+    "festival_name": "Wilderness Festival 2025",
+    "start_date": "2025-07-31",
+    "end_date": "2025-08-03",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Basement Jaxx"
+      ]
+    }
+  },
+  {
+    "festival_name": "Wireless Festival 2025",
+    "start_date": "2025-07-11",
+    "end_date": "2025-07-13",
+    "main_stages": ["Main Stage"],
+    "stages": {
+      "Main Stage": [
+        "Drake",
+        "Burna Boy",
+        "Vybz Kartel",
+        "PARTYNEXTDOOR",
+        "Summer Walker",
+        "Boy Better Know"
+      ]
+    }
+  }
+];
+
+// Helper function to get festival by id
+export const getFestivalById = (id: string): FestivalData | undefined => {
+  return festivals.find(festival => 
+    festival.festival_name.toLowerCase().replace(/\s+/g, '') === id.toLowerCase()
+  );
+};
+
+// This function will organize artists by stage, putting main stages first
+export const getOrganizedArtistsByFestival = (festivalId: string): { stageName: string; artists: string[]; isMainStage: boolean }[] => {
+  const festival = getFestivalById(festivalId);
+  if (!festival) return [];
+  
+  const stages = Object.keys(festival.stages);
+  return stages.sort((a, b) => {
+    // Sort logic: main stages first, then alphabetically
+    const aIsMain = festival.main_stages.includes(a);
+    const bIsMain = festival.main_stages.includes(b);
+    
+    if (aIsMain && !bIsMain) return -1;
+    if (!aIsMain && bIsMain) return 1;
+    return a.localeCompare(b);
+  }).map(stageName => {
+    const artists = festival.stages[stageName].sort((a, b) => a.localeCompare(b));
+    return {
+      stageName,
+      artists,
+      isMainStage: festival.main_stages.includes(stageName)
+    };
+  });
+};

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -1,3 +1,4 @@
+
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { supabase } from "@/integrations/supabase/client";
@@ -71,7 +72,7 @@ const Auth = () => {
                 <span></span>
               </div>
             </div>
-            <h1 className="text-3xl font-bold mb-2">Welcome to Roadtrip Rhythm</h1>
+            <h1 className="text-3xl font-bold mb-2">Welcome to Roadtrip Radio</h1>
             <p className="text-muted-foreground">Connect with Spotify to create your road trip playlists</p>
           </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -6,14 +6,6 @@ import Map from "@/components/Map";
 import PlaylistGenerator from "@/components/PlaylistGenerator";
 import { MapPin, Music } from "lucide-react";
 
-const MOCK_ARTIST_LOCATIONS = [
-  { id: "1", name: "Coldplay", location: "London, UK", lat: 51.5074, lng: -0.1278 },
-  { id: "2", name: "Mumford & Sons", location: "London, UK", lat: 51.5074, lng: -0.1278 },
-  { id: "3", name: "The Killers", location: "Las Vegas, Nevada", lat: 36.1699, lng: -115.1398 },
-  { id: "4", name: "Florence and the Machine", location: "London, UK", lat: 51.5074, lng: -0.1278 },
-  { id: "5", name: "Elbow", location: "Manchester, UK", lat: 53.4808, lng: -2.2426 }
-];
-
 const Index = () => {
   const [route, setRoute] = useState<{
     startLocation: string;
@@ -21,7 +13,7 @@ const Index = () => {
     festival: string;
   } | null>(null);
   
-  const [artistLocations, setArtistLocations] = useState<typeof MOCK_ARTIST_LOCATIONS | null>(null);
+  const [artistLocations, setArtistLocations] = useState<any[] | null>(null);
   
   const handleFormSubmit = (data: {
     startLocation: string;
@@ -30,10 +22,8 @@ const Index = () => {
   }) => {
     setRoute(data);
     
-    // Simulate API call to get artists
-    setTimeout(() => {
-      setArtistLocations(MOCK_ARTIST_LOCATIONS);
-    }, 1000);
+    // Clear any previous artist locations when selecting a new festival
+    setArtistLocations([]);
   };
 
   return (
@@ -48,7 +38,7 @@ const Index = () => {
             <span>Discover artists along your journey</span>
           </div>
           <h1 className="text-4xl sm:text-6xl font-bold mb-4 text-gradient leading-tight">
-            Roadtrip Rhythm Radio
+            Roadtrip Radio
           </h1>
           <p className="text-xl text-muted-foreground">
             Create the perfect playlist for your journey to your favorite music festival
@@ -107,7 +97,7 @@ const Index = () => {
               <span></span>
               <span></span>
             </div>
-            <h3 className="font-bold">Roadtrip Rhythm Radio</h3>
+            <h3 className="font-bold">Roadtrip Radio</h3>
           </div>
           <p className="text-sm text-muted-foreground">
             The perfect playlist for your festival road trip journey

--- a/src/utils/spotify.ts
+++ b/src/utils/spotify.ts
@@ -5,6 +5,10 @@ export interface SpotifyArtist {
   id: string;
   name: string;
   images: { url: string }[];
+  genres?: string[];
+  followers?: { total: number };
+  popularity?: number;
+  external_urls?: { spotify: string };
 }
 
 export interface SpotifyTrack {
@@ -19,6 +23,16 @@ export interface SpotifyTrack {
     name: string;
     images: { url: string }[];
   };
+}
+
+export interface ArtistWithDetails {
+  name: string;
+  id: string;
+  imageUrl: string | null;
+  spotifyId: string | null;
+  topTrack: string | null;
+  popularity: number | null;
+  genres: string[];
 }
 
 class SpotifyAPI {
@@ -47,12 +61,13 @@ class SpotifyAPI {
       });
 
       if (!response.ok) {
-        const errorData = await response.json();
+        const errorData = await response.json().catch(() => ({}));
         throw new Error(errorData.error?.message || "Error calling Spotify API");
       }
 
       return await response.json();
     } catch (error) {
+      console.error("Spotify API Error:", error);
       toast.error("Spotify API Error", {
         description: error.message,
       });
@@ -64,14 +79,68 @@ class SpotifyAPI {
     return this.fetchWithAuth('/me');
   }
 
-  async searchArtists(query: string) {
+  async searchArtists(query: string, limit = 1) {
     const params = new URLSearchParams({
       q: query,
       type: 'artist',
-      limit: '10',
+      limit: limit.toString(),
     });
 
-    return this.fetchWithAuth(`/search?${params}`);
+    const result = await this.fetchWithAuth(`/search?${params}`);
+    return result.artists.items;
+  }
+
+  async getArtistDetails(artistName: string): Promise<ArtistWithDetails | null> {
+    try {
+      // Search for the artist
+      const artists = await this.searchArtists(artistName);
+      
+      if (!artists || artists.length === 0) {
+        return {
+          name: artistName,
+          id: null,
+          imageUrl: null,
+          spotifyId: null,
+          topTrack: null,
+          popularity: null,
+          genres: []
+        };
+      }
+
+      const artist = artists[0];
+      let topTrack = null;
+
+      try {
+        // Get artist's top tracks
+        const topTracks = await this.getArtistTopTracks(artist.id);
+        if (topTracks && topTracks.tracks && topTracks.tracks.length > 0) {
+          topTrack = topTracks.tracks[0].name;
+        }
+      } catch (error) {
+        console.error("Error fetching top tracks:", error);
+      }
+
+      return {
+        name: artistName,
+        id: artist.id,
+        imageUrl: artist.images && artist.images.length > 0 ? artist.images[0].url : null,
+        spotifyId: artist.id,
+        topTrack,
+        popularity: artist.popularity || null,
+        genres: artist.genres || []
+      };
+    } catch (error) {
+      console.error(`Error fetching artist details for ${artistName}:`, error);
+      return {
+        name: artistName,
+        id: null,
+        imageUrl: null,
+        spotifyId: null,
+        topTrack: null,
+        popularity: null,
+        genres: []
+      };
+    }
   }
 
   async getArtistTopTracks(artistId: string) {


### PR DESCRIPTION
- Update app name to Roadtrip Radio.
- Integrate festival data and artist selection.
- Fetch artist details from Spotify API.
- Order artists by stage and alphabetically.